### PR TITLE
ADB Fix

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -44,7 +44,7 @@ function getIpAddress() {
 
 function adbConnect(ipAddress) {
     console.log(`- Connecting to Quest wirelessly...`)
-    exec(`${adb} tcpip 5555 && adb connect ${ipAddress}:5555`, (error, stdout, stderr) => {
+    exec(`${adb} tcpip 5555 && ${adb} connect ${ipAddress}:5555`, (error, stdout, stderr) => {
         if (error) {
             console.log(`- [CO]error: ${error.message}`);
             return;


### PR DESCRIPTION
I had an issue where the windows bash was not recognising ADB as an executable so I just changed the second exec command to run through the same directory as the first one instead of just calling ADB 